### PR TITLE
header, footer 컴포넌트 추가

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
         "cra-template": "1.2.0",
         "react": "^19.0.0",
         "react-dom": "^19.0.0",
+        "react-router-dom": "^7.1.4",
         "react-scripts": "5.0.1",
         "styled-components": "^6.1.14"
       },
@@ -3549,6 +3550,12 @@
         "@types/express-serve-static-core": "*",
         "@types/node": "*"
       }
+    },
+    "node_modules/@types/cookie": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/@types/cookie/-/cookie-0.6.0.tgz",
+      "integrity": "sha512-4Kh9a6B2bQciAhf7FSuMRRkUWecJgJu9nPnx3yzpsfXX/c50REIqpHY4C82bXP90qrLtXtkDxTZosYO3UpOwlA==",
+      "license": "MIT"
     },
     "node_modules/@types/eslint": {
       "version": "8.56.12",
@@ -13800,6 +13807,55 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/react-router": {
+      "version": "7.1.4",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-7.1.4.tgz",
+      "integrity": "sha512-aJWVrKoLI0nIK1lfbTU3d5al1ZEUiwtSus/xjYL8K5sv2hyPesiOIojHM7QnaNLVtroOB1McZsWk37fMQVoc6A==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/cookie": "^0.6.0",
+        "cookie": "^1.0.1",
+        "set-cookie-parser": "^2.6.0",
+        "turbo-stream": "2.4.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=18",
+        "react-dom": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/react-router-dom": {
+      "version": "7.1.4",
+      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-7.1.4.tgz",
+      "integrity": "sha512-p474cAeRKfPNp+9QtpdVEa025iWLIIIBhYCnjsSwFmZH3c5DBHOc7vB7zmL6lL747o0ArfrLblNTebtL6lt0lA==",
+      "license": "MIT",
+      "dependencies": {
+        "react-router": "7.1.4"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=18",
+        "react-dom": ">=18"
+      }
+    },
+    "node_modules/react-router/node_modules/cookie": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-1.0.2.tgz",
+      "integrity": "sha512-9Kr/j4O16ISv8zBBhJoi4bXOYNTkFLOqSL3UDB0njXxCXNezjeyVrJyGOWtgfs/q2km1gwBcfH8q1yEGoMYunA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/react-scripts": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/react-scripts/-/react-scripts-5.0.1.tgz",
@@ -14701,6 +14757,12 @@
       "engines": {
         "node": ">= 0.8.0"
       }
+    },
+    "node_modules/set-cookie-parser": {
+      "version": "2.7.1",
+      "resolved": "https://registry.npmjs.org/set-cookie-parser/-/set-cookie-parser-2.7.1.tgz",
+      "integrity": "sha512-IOc8uWeOZgnb3ptbCURJWNjWUPcO3ZnTTdzsurqERrP6nPyv+paC55vJM0LpOlT2ne+Ix+9+CRG1MNLlyZ4GjQ==",
+      "license": "MIT"
     },
     "node_modules/set-function-length": {
       "version": "1.2.2",
@@ -16141,6 +16203,12 @@
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
       "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
       "license": "0BSD"
+    },
+    "node_modules/turbo-stream": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/turbo-stream/-/turbo-stream-2.4.0.tgz",
+      "integrity": "sha512-FHncC10WpBd2eOmGwpmQsWLDoK4cqsA/UT/GqNoaKOQnT8uzhtCbg3EoUDMvqpOSAI0S26mr0rkjzbOO6S3v1g==",
+      "license": "ISC"
     },
     "node_modules/type-check": {
       "version": "0.4.0",

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
     "cra-template": "1.2.0",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
+    "react-router-dom": "^7.1.4",
     "react-scripts": "5.0.1",
     "styled-components": "^6.1.14"
   },

--- a/src/assets/icon-lock.svg
+++ b/src/assets/icon-lock.svg
@@ -1,0 +1,11 @@
+<svg width="36" height="36" viewBox="0 0 36 36" fill="none" xmlns="http://www.w3.org/2000/svg">
+<g clip-path="url(#clip0_16_292)">
+<path d="M25.5 13.7092H10.5C8.42893 13.7092 6.75 15.3882 6.75 17.4592V28.7092C6.75 30.7803 8.42893 32.4592 10.5 32.4592H25.5C27.5711 32.4592 29.25 30.7803 29.25 28.7092V17.4592C29.25 15.3882 27.5711 13.7092 25.5 13.7092Z" stroke="#5D5A88" stroke-width="5" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M18 2.45923C16.0109 2.45923 14.1032 3.24941 12.6967 4.65593C11.2902 6.06245 10.5 7.9701 10.5 9.95923V13.7092H25.5V9.95923C25.5 7.9701 24.7098 6.06245 23.3033 4.65593C21.8968 3.24941 19.9891 2.45923 18 2.45923V2.45923Z" stroke="#5D5A88" stroke-width="5" stroke-linecap="round" stroke-linejoin="round"/>
+</g>
+<defs>
+<clipPath id="clip0_16_292">
+<rect width="36" height="36" fill="white"/>
+</clipPath>
+</defs>
+</svg>

--- a/src/components/footer.jsx
+++ b/src/components/footer.jsx
@@ -1,0 +1,28 @@
+import styled from "styled-components";
+import Logo from "./logo";
+
+const Wrapper = styled.div`
+    display: flex;
+    align-items: center;
+    justify-content: space-around;
+    width: 100%;
+    gap: 50%;
+    padding: 30px 0px;
+    bottom: 0px;
+`;
+
+const Text = styled.span`
+    font-size: 14px;
+    color: #9795B5;
+`;
+
+function Footer(props) {
+    return (
+        <Wrapper>
+            <Logo fontSize="26px" />
+            <Text>Copyright © 2025 SpamScanner | All Rights Reserved </Text>
+        </Wrapper>
+    );
+}
+
+export default Footer;

--- a/src/components/header.jsx
+++ b/src/components/header.jsx
@@ -1,0 +1,59 @@
+import styled from "styled-components";
+import { useState } from "react";
+import Logo from "./logo";
+import { useNavigate } from "react-router-dom";
+
+const Wrapper = styled.div`
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    padding: 30px 0px;
+    width: 100%;
+`;
+
+const LoginButton = styled.div`
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    position: absolute;
+    right: 100px;
+    color: ${(props) => props.isLogin ? "white" : "#5D5A88"};
+    background-color: ${(props) => props.isLogin ? "#5D5A88" : "white"};
+    font-size: 14px;
+    border: 1px solid #D4D2E3;
+    border-radius: 30px;
+    margin: 0;
+    padding: 10px 20px;
+    cursor: pointer;
+`;
+
+function Header(props) {
+    const [isLogin, setIsLogin] = useState(true); // 테스트용 true, 기본은 false로 설정 
+    const navigate = useNavigate();
+
+    const onClick = () => {
+        if (isLogin) {
+            const ok = window.confirm("정말 로그아웃 하시겠습니까?");
+            if (ok) {
+                // 로그아웃 구현하기?
+                setIsLogin(false);
+                navigate("/");
+            }
+        }
+        else { // 로그인하지 않았을 경우
+            // 로그인 페이지로 이동
+            navigate("/");
+        }
+    }
+
+    return (
+        <Wrapper>
+            <Logo fontSize="30px" />
+            <LoginButton onClick={onClick} isLogin={isLogin}>
+                {isLogin ? "로그아웃" : "로그인"}
+                </LoginButton>
+        </Wrapper>
+    );
+}
+
+export default Header;

--- a/src/components/logo.jsx
+++ b/src/components/logo.jsx
@@ -1,0 +1,42 @@
+import styled from "styled-components";
+import lock from "../assets/icon-lock.svg";
+import { useNavigate } from "react-router-dom";
+
+const Wrapper = styled.div`
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    gap: 10px;
+    cursor: pointer;
+`;
+
+const Img = styled.img`
+    width: ${(props) => props.fontSize ? props.fontSize : "36px"};
+`;
+
+const Text = styled.span`
+    font-family: "Pretendard";
+    font-weight: bold;
+    color: ${(props) => props.color ? props.color : "black"};
+    font-size: ${(props) => props.fontSize ? props.fontSize : "36px"};
+`;
+
+function Logo(props) {
+    const { fontSize } = props;
+    const navigate = useNavigate();
+
+    // 로고 클릭 시 홈페이지로 이동
+    const onClick = () => {
+        navigate("/");
+    }
+
+    return (
+        <Wrapper onClick={onClick}>
+            <Img fontSize={fontSize} src={lock} />
+            <Text fontSize={fontSize} color="#5D5A88">스팸</Text>
+            <Text fontSize={fontSize} color="#8D8BA7">스캐너</Text>
+        </Wrapper>
+    );
+}
+
+export default Logo;


### PR DESCRIPTION
### 내용
- 모든 페이지에 사용되는 header, footer 컴포넌트 추가
- logo 컴포넌트를 header와 footer에서 둘 다 사용
- 리액트 라우터 돔(react-router-dom) 패키지 추가
- 로고 클릭 시 메인 페이지("/")로 이동하게 설정

### 구현해야하는 부분
- 오른쪽 위 로그인, 로그아웃 버튼 onClick 구현해야 함
  - 로그아웃 버튼 클릭 시 confirm으로 확인창을 띄웠으나 이후 로직은 만들어지지 않음