### PR TITLE
전체 페이지 점검 + 회원가입 폼 변경

### DIFF
--- a/src/components/Footer.jsx
+++ b/src/components/Footer.jsx
@@ -6,26 +6,27 @@ const Wrapper = styled.div`
     display: flex;
     align-items: center;
     justify-content: space-between;
-    padding: 30px 30px;
+    padding: 72px 110px;
     width: 100%;
     bottom: 0px;
     // 반응형 스타일 추가
-    @media (max-width: 768px) {
+    @media (max-width: 900px) {
         flex-direction: column; 
         text-align: center;       
         gap: 10px;                
+        padding: 72px 20px;
     }
 `;
 
 const Text = styled.span`
-    font-size: 14px;
+    font-size: 18px;
     color: #9795B5;
 `;
 
 function Footer(props) {
     return (
         <Wrapper>
-            <Logo fontSize="26px" />
+            <Logo fontSize="34px" />
             <Text>Copyright © 2025 SpamScanner | All Rights Reserved </Text>
         </Wrapper>
     );

--- a/src/components/Header.jsx
+++ b/src/components/Header.jsx
@@ -9,7 +9,7 @@ const Wrapper = styled.div`
     align-items: center;
     padding: 30px 0px;
     width: 100%;
-    gap: 20px;
+    gap: 1rem;
 `;
 
 const LoginButton = styled.div`
@@ -22,7 +22,7 @@ const LoginButton = styled.div`
     cursor: pointer;
 
     // 반응형 스타일 추가
-    @media (min-width: 768px) {
+    @media (min-width: 650px) {
         position: absolute;
         right: 100px;
     }

--- a/src/components/Logo.jsx
+++ b/src/components/Logo.jsx
@@ -5,7 +5,7 @@ import { useNavigate } from "react-router-dom";
 
 const Wrapper = styled.div`
     display: flex;
-    gap: 10px;
+    gap: 0.5rem;
     cursor: pointer;
 `;
 

--- a/src/pages/analysis/Analysis.jsx
+++ b/src/pages/analysis/Analysis.jsx
@@ -32,7 +32,7 @@ const Text = styled.span`
 const TextArea = styled.textarea`
     box-sizing: border-box;
     display: flex;
-    font-size: 14px;
+    font-size: 18px;
     font-family: 'Pretendard-Regular';
     color: #5D5A88;
     background-color: white;
@@ -55,7 +55,7 @@ const InputField = styled.div`
 
 const Input = styled.input`
     padding: 16px 20px;
-    font-size: 14px;
+    font-size: 18px;
     font-weight: 900;
     background-color: #5D5A88;
     color: white;
@@ -74,7 +74,7 @@ const Error = styled.span`
     color: tomato;
     font-size: 13px;
     position: absolute;
-    margin-top: 2px;
+    margin-top: 4px;
 `;
 
 function Analysis(props) {
@@ -113,9 +113,9 @@ function Analysis(props) {
         <>
             {isLoading ? <Loading /> :
                 <Wrapper>
-                    <Text fontSize="35px" color="#5D5A88">스팸 분석기</Text>
+                    <Text fontSize="44px" color="#5D5A88">스팸 분석기</Text>
                     <Form onSubmit={handleSubmit(onSubmit, onInvalid)}>
-                        <Text fontSize="16px" color="#5D5A88">이 메시지도 스팸일까요?</Text>
+                        <Text fontSize="18px" color="#5D5A88">이 메시지도 스팸일까요?</Text>
                         <InputField>
                             <TextArea rows={15} maxLength={1000} placeholder="수신한 텍스트를 입력해주세요."
                                 {...register("inputText", {

--- a/src/pages/analysis/Loading.jsx
+++ b/src/pages/analysis/Loading.jsx
@@ -17,6 +17,7 @@ const Wrapper = styled.div`
     display: flex;
     flex-direction: column;
     justify-content: center;
+    align-items: center;
     gap: 105px;
 `;
 
@@ -34,7 +35,7 @@ const Circle = styled.div`
 
     animation: ${pulse} 2s infinite ease-in-out;
 `;
-
+ 
 const Img = styled.img`
     width: ${(props) => props.fontSize ? props.fontSize : "36px"};
 `;

--- a/src/pages/login/Login.jsx
+++ b/src/pages/login/Login.jsx
@@ -1,8 +1,8 @@
-  import { useForm } from "react-hook-form";
-  import { Link } from "react-router-dom"; 
-  import styled from "styled-components";
+import { useForm } from "react-hook-form";
+import { Link, useNavigate } from "react-router-dom";
+import styled from "styled-components";
 
-  const Wrapper = styled.div`
+const Wrapper = styled.div`
       display: flex;
       flex-direction: column;
       align-items: center;
@@ -10,25 +10,27 @@
       height: 680px;
   `;
 
-  const Title = styled.span`
+const Title = styled.span`
       font-size: 36px;
       font-weight: bold;
+    padding-bottom: 20px;
       color: #5D5A88;
   `;
 
-  const Form = styled.form`
+const Form = styled.form`
       display: flex;
       flex-direction: column;
       width: 380px; 
   `;
 
-  const Label = styled.label`
+const Label = styled.label`
       font-size: 14px;
-      margin-top: 20px;
+      margin-top: 15px;
       color: #8D8BA7;
   `;
 
-  const Input = styled.input`
+const Input = styled.input`
+    font-family: 'Pretendard-Regular';
       padding: 16px 20px;
       margin-top: 5px;
       font-size: 16px;
@@ -47,16 +49,18 @@
       }
   `;
 
-  const Button = styled.input`
+const Button = styled.input`
+    font-family: 'Pretendard-Regular';
       font-size: 14px;
       font-weight: 900;
       background-color: #5D5A88;
       color: white;
       border: 1px solid #5D5A88;
       border-radius: 50px;
-      margin-top: 40px;
+      margin-top: 20px;
       cursor: pointer;
       height: 50px;
+      transition: background-color 0.3s ease, opacity 0.3s ease;
 
       &:hover {
           opacity: 0.8;
@@ -66,10 +70,13 @@
           background-color: #dadada;
           border: none;
           cursor: not-allowed;
+          &:hover {
+            opacity: 1;
+          }
       }
   `;
 
-  const StyledLink = styled(Link)`
+const StyledLink = styled(Link)`
       font-size: 14px;
       font-weight: 900;
       background-color: white;
@@ -84,58 +91,74 @@
       align-items: center; 
       justify-content: center; 
       text-decoration: none;
-
   `;
 
-  const Error = styled.span`
-      color: tomato;
-      font-size: 13px;
-  `;
+const InputField = styled.div`
+    width: 100%;
+    display: flex;
+    flex-direction: column;
+    padding-bottom: 20px;
+    position: relative;
+`;
 
-  function Login() {
-      const {
-          register,
-          handleSubmit,
-          formState: { isValid, errors }
-      } = useForm({
-          mode: "onBlur",
-      });
+const Error = styled.span`
+    color: tomato;
+    font-size: 13px;
+    position: absolute;
+    bottom: 0px;
+    margin-top: 2px;
+`;
 
-      const onSubmit = (data) => {
-          try {
-              console.log("로그인 데이터:", data);
-              alert("로그인 성공!");
-          } catch (error) {
-              console.log(error);
-          }
-      };
+function Login() {
+    const navigate = useNavigate();
+    const {
+        register,
+        handleSubmit,
+        formState: { isValid, errors }
+    } = useForm({
+        mode: "onBlur",
+    });
 
-      return (
-          <Wrapper>
-              <Title>로그인</Title>
-              <Form onSubmit={handleSubmit(onSubmit)}>
-                  <Label>아이디</Label>
-                  <Input placeholder="아이디를 입력해주세요." type="text"
-                      {...register('id', {
-                          required: '이 필드는 필수 입력 항목입니다.',
-                      })}
-                  />
-                  {errors.id && <Error>{errors.id.message}</Error>}
+    const onSubmit = (data) => {
+        try {
+            console.log("로그인 데이터:", data);
+            alert("로그인 성공!");
+            navigate("/analysis");
+        } catch (error) {
+            console.log(error);
+        }
+    };
 
-                  <Label>비밀번호</Label>
-                  <Input placeholder="비밀번호를 입력해주세요." type="password"
-                      {...register('password', {
-                          required: '이 필드는 필수 입력 항목입니다.',
-                      })}
-                  />
-                  {errors.password && <Error>{errors.password.message}</Error>}
+    return (
+        <Wrapper>
+            <Title>로그인</Title>
+            <Form onSubmit={handleSubmit(onSubmit)}>
+                <InputField>
+                    <Label>아이디</Label>
+                    <Input placeholder="아이디를 입력해주세요." type="text"
+                        {...register('id', {
+                            required: '필수 입력 사항입니다.',
+                        })}
+                    />
+                    {errors.id && <Error>{errors.id.message}</Error>}
+                </InputField>
 
-                  <Button type="submit" value="로그인" disabled={!isValid} />
+                <InputField>
+                    <Label>비밀번호</Label>
+                    <Input placeholder="비밀번호를 입력해주세요." type="password"
+                        {...register('password', {
+                            required: '필수 입력 사항입니다.',
+                        })}
+                    />
+                    {errors.password && <Error>{errors.password.message}</Error>}
+                </InputField>
 
-                  <StyledLink to="/register">회원가입</StyledLink>
-              </Form>
-          </Wrapper>
-      );
-  }
+                <Button type="submit" value="로그인" disabled={!isValid} />
 
-  export default Login;
+                <StyledLink to="/register">회원가입</StyledLink>
+            </Form>
+        </Wrapper>
+    );
+}
+
+export default Login;

--- a/src/pages/login/LoginPage.jsx
+++ b/src/pages/login/LoginPage.jsx
@@ -15,7 +15,7 @@ const Main = styled.div`
     display: flex;
     align-items: center;
     justify-content: space-around;
-    padding: 30px 0px;
+    padding: 0.5rem 0px;
 `;
 
 const Img = styled.img`
@@ -24,7 +24,7 @@ const Img = styled.img`
     }
 `;
 
-function RegisterPage(props) {
+function LoginPage(props) {
     return (
         <Wrapper>
             <Header fontSize="50px" />
@@ -37,4 +37,4 @@ function RegisterPage(props) {
     );
 }
 
-export default RegisterPage;
+export default LoginPage;

--- a/src/pages/register/Register.jsx
+++ b/src/pages/register/Register.jsx
@@ -1,4 +1,5 @@
 import { useForm } from "react-hook-form";
+import { useNavigate } from "react-router-dom";
 import styled from "styled-components";
 
 const Wrapper = styled.div`
@@ -56,11 +57,20 @@ const Input = styled.input`
         color: white;
         border: 1px solid #5D5A88;
         border-radius: 50px;
-        margin-top: 20px;
+        margin-top: 30px;
         cursor: pointer;
+        
         &:hover {
             opacity: 0.8;
         }
+        &:disabled {
+          background-color: #dadada;
+          border: 1px solid #dadada;
+          cursor: not-allowed;
+          &:hover {
+            opacity: 1;
+          }
+      }
     }
 `;
 
@@ -80,9 +90,30 @@ const Error = styled.span`
     margin-top: 2px;
 `;
 
+const Select = styled.select`
+    font-family: 'Pretendard-Regular';
+    padding: 16px 20px;
+    width: 100%; 
+    height: 51.2px;
+    margin-top: 5px;
+    font-size: 16px;
+    background-color: #F9F9FF;
+    color: #5D5A88;
+    //box-shadow: 0px 3px 5px rgb(179, 177, 205);
+    border: none;
+    border-radius: 10px;
+    transition: background-color 0.3s ease, opacity 0.3s ease;  // 애니메이션 효과 추가
+
+    &:focus {
+        outline: 0.5px solid hsl(243.75, 32.00000000000001%, 90.19607843137256%);
+        background-color: #f5f5fe;
+    }
+`;
+
 const REQUIRED_MESSAGE = '필수 입력 사항입니다.';
 
 function Register(props) {
+    const navigate = useNavigate();
     // useForm으로 폼 상태 관리함 = useState 불필요
     // 이벤트 핸들링, 유효성 검사 모두 처리해줌 = onChange 불필요
     const {
@@ -99,6 +130,9 @@ function Register(props) {
         // 회원가입 로직 구현
         try {
             console.log(data);
+            navigate("/");
+            alert("회원가입 되었습니다.");
+
         } catch (error) {
             console.log(error);
         }
@@ -149,39 +183,18 @@ function Register(props) {
 
                 <InputField>
                     <Label>생년월일</Label>
-                    <Input placeholder="태어난 연도를 입력해주세요. ex)2001" type="number"
-                        {...register('birthYear', {
-                            required: REQUIRED_MESSAGE,
-                            min: {
-                                value: 1900,
-                                message: "1900년 이후 출생년도만 입력 가능합니다."
-                            },
-                            max: {
-                                value: 2025,
-                                message: "2025년 이전 출생년도만 입력 가능합니다."
-                            }
-                        })}
-                    />
+                    <Select {...register('birthYear', { required: REQUIRED_MESSAGE })}>
+                        <option value="">태어난 연도를 선택해주세요.</option>
+                        {Array.from({ length: 106 }, (_, i) => 1920 + i).map((year, index) => (
+                            <option key={index} value={year}>{year}</option>
+                        ))}
+                    </Select>
                     {errors.birthYear && <Error>{errors.birthYear.message}</Error>}
-                </InputField>
-
-                <InputField>
-                    <Label>이메일</Label>
-                    <Input placeholder="이메일 주소를 입력해주세요." type="email"
-                        {...register('email', {
-                            required: REQUIRED_MESSAGE,
-                            pattern: {
-                                value: /^[0-9a-zA-Z]([-_.]?[0-9a-zA-Z])*@[0-9a-zA-Z]([-_.]?[0-9a-zA-Z])*\.[a-zA-Z]{2,3}$/g,
-                                message: '올바른 이메일 주소를 입력해주세요.'
-                            }
-                        })}
-                    />
-                    {errors.email && <Error>{errors.email.message}</Error>}
                 </InputField>
 
                 <Input type="submit" value={"회원가입"} disabled={!isValid} />
             </Form>
-        </Wrapper>
+        </Wrapper >
     );
 }
 

--- a/src/pages/register/RegisterPage.jsx
+++ b/src/pages/register/RegisterPage.jsx
@@ -15,7 +15,7 @@ const Main = styled.div`
     display: flex;
     align-items: center;
     justify-content: space-around;
-    padding: 30px 0px;
+    padding: 0.5rem 0px;
 `;
 
 const Img = styled.img`


### PR DESCRIPTION
### 1. 회원가입 수정
- 이메일 폼 삭제
- 연도 입력 폼을 드롭다운 형식으로 변경(클릭 시 1920~2025 중 선택)
  - select와 option으로 구현
- 유효성 검사 실패 시 로그인 페이지와 동일하게 제출 버튼 비활성화 시킴

### 2. 전체 페이지 점검
- 로그인 유효성 검사 폼을 회원가입과 동일하게 변경(유효성 검사 시 폼이 늘어나는 현상 제거)
- 로그인 성공 시 분석 페이지(/analysis)로 이동
- 일부 속성(padding, gap 등)값 및 Header, Footer에 전달되는 값 변경
  - 분석 페이지는 폰트 사이즈를 피그마와 동일하게 설정함
  - 모바일에서 Header Footer가 깨지는 걸 방지하기 위해 몇몇 속성값을 rem으로 설정(전체적으로 rem으로 설정하는게 좋을 것 같기도? 피그마 맞춰서?)
  
![image](https://github.com/user-attachments/assets/02a74ff0-28a0-4d03-abaf-fac68f08c2e2)
